### PR TITLE
Update README.md, Dockerfile, makefile_smi-build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,18 @@ SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
 # packages to support the development environment
 # Ignore DL3008: Pin versions in apt-get install.
 # hadolint ignore=DL3008
-RUN apt-get update && \
+# NOTE: The upgrade is absolutely required for ubuntu 20.04 becase the
+# pam dev lib was left out of the original release.
+# The libpam0g-dev may have different names under other linux distributions.
+# the --no-install-recommends significantly reduces docker image size
+
+RUN apt-get update && apt-get -y upgrade && \
     apt-get install -y --no-install-recommends \
+    openssl \
     docker.io \
     build-essential \
     libssl-dev \
-    libpam0g \
+    libpam0g-dev \
     ack-grep \
     git \
     curl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
 # Package installations
 # Includes packages for docker, OpenPegasus support packages, and
 # packages to support the development environment
+
+# Ignore DL3005 that disallows apt-get upgrade
+# hadolint ignore=DL3005
 # Ignore DL3008: Pin versions in apt-get install.
 # hadolint ignore=DL3008
 # NOTE: The upgrade is absolutely required for ubuntu 20.04 becase the
@@ -18,6 +21,9 @@ SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
 # The libpam0g-dev may have different names under other linux distributions.
 # the --no-install-recommends significantly reduces docker image size
 
+# Ignore DL3005 that disallows apt-get upgrade
+# Ignore DL3008: Pin versions in apt-get install.
+# hadolint ignore=DL3005,DL3008
 RUN apt-get update && apt-get -y upgrade && \
     apt-get install -y --no-install-recommends \
     openssl \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ make clean    Remove the build image from the local machine.
 ```
 
 ### How to Build the SMI Server Image
-Using the build image the server image can now be built.  Run the following command line. 
+Using the build image the server image can now be built.  Run the following command line.
 
 ```console
 sudo docker run -it --rm -v /home/<username>/.ssh:/root/.ssh -v /var/run/docker.sock:/var/run/docker.sock smi-build:tag /bin/bash
@@ -61,7 +61,7 @@ sudo docker run -it --rm -v /home/<username>/.ssh:/root/.ssh -v /var/run/docker.
 The container will terminate though after it finishes executing the specified command.
 
 To only build, test and create the server image run these commands in build image bash shell.
- 
+
 ```console
 make build
 make docker-build-server-image
@@ -82,8 +82,16 @@ peterlamanna/smi-build:0.1.0
 To run the server simply execute this command line.
 
 ```console
-sudo docker run -it --rm -p 127.0.0.1:5988:5988 smi-server:0.1.2 /bin/bash
+sudo docker run -it --rm -p 127.0.0.1:5988:5988 -p 127.0.0.1:5989:5989 smi-server:0.1.2 /bin/bash
 ```
+
+or to load the server image and start OpenPegasus when the server starts enter the run command
+without the last parameter ("/bin/bash")
+
+```console
+sudo docker run -it --rm -p 127.0.0.1:5988:5988 -p 127.0.0.1:5989:5989 smi-server:0.1.2
+```
+
 
 Again, the bash shell will have the SMI root directory as the current working directory.  From there you can execute any cimserver of cimcli command.  To start the server simply execute the following.
 

--- a/makefile_smi-build
+++ b/makefile_smi-build
@@ -97,12 +97,14 @@ test-server:
 	cd ${PEGASUS_ROOT}
 
 	@echo "Testing the server build..."
-	make repository; make testrepository
+	make repository
+	make testrepository
 	make tests
 
 	# recreate after tests.  Note that we should actually clear the
 	# home directory of a number of items and leave just what is required
-	make repository; make testrepository
+	make repository
+	make testrepository
 
 remove-uneeded-components:
 	@echo "Remove the server unwanted files in the build container..."

--- a/makefile_smi-build
+++ b/makefile_smi-build
@@ -97,8 +97,12 @@ test-server:
 	cd ${PEGASUS_ROOT}
 
 	@echo "Testing the server build..."
-	make repository make testrepository
+	make repository; make testrepository
 	make tests
+
+	# recreate after tests.  Note that we should actually clear the
+	# home directory of a number of items and leave just what is required
+	make repository; make testrepository
 
 remove-uneeded-components:
 	@echo "Remove the server unwanted files in the build container..."


### PR DESCRIPTION
Modify docker file to add other libraries that are not appearing in the
build image including openssl.

Also does an apt-get upgrade in in addition to the update to actually
install updates.

Adds one line to the makefile_smi-build to recreate the repository after
tests