### PR TITLE
Cleanup of Dockerfiles and make_smi_build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,26 +41,110 @@ RUN apt-get update && apt-get -y upgrade && \
 
 # Pegasus file paths
 ENV PEGASUS_SMI_ROOT=/root/smi
+# PEGASUS_HOME defines the target location for pegasus builds including
+# object files, executables, the repository, and security files
 ENV PEGASUS_HOME=${PEGASUS_SMI_ROOT}/home
+# Defines the top level of the pegasus source files (pegasus)
 ENV PEGASUS_ROOT=${PEGASUS_SMI_ROOT}/OpenPegasus/pegasus
 
 # Create directory structure
 RUN mkdir -p ${PEGASUS_HOME} && \
     mkdir -p /root/.ssh
 
-# Build settings (Debug is currently required for build success)
+# Build settings
 # Settings below that are flags, with values set to true, enable the action
 # simply through the existance of the variable.  The variables value has no
 # effect.
+# See pegasus/doc/BuildAndReleaseOpetions.html for more detailed information
+# on the options
+
+# Platform defined for the docker image
 ENV PEGASUS_PLATFORM=LINUX_X86_64_GNU
-ENV PEGASUS_DEBUG=true
-ENV PATH=${PEGASUS_HOME}/bin:$PATH
+
 ENV PEGASUS_USE_DEFAULT_MESSAGES=true
+
+# Define the connection and pegasus security environment including
+# ssl, pam, and pegasus usergroup
 ENV PEGASUS_HAS_SSL=true
-ENV PEGASUS_PAM_AUTHENTICATION=true
-ENV PEGASUS_CLIENT_TRACE_ENABLE=true
-ENV PEGASUS_ENABLE_EXECQUERY=true
 ENV OPENSSL=/usr
+ENV PEGASUS_PAM_AUTHENTICATION=true
+# Enable pegasus usergroup authorization
+# TODO document the usergroup authorization capability
+# ENV PEGASUS_ENABLE_USERGROUP_AUTHORIZATION=true
+
+# Query capabilities. Enable execquery and CQL
+ENV PEGASUS_ENABLE_EXECQUERY=true
+ENV PEGASUS_ENABLE_CQL=true
+
+# If set to true, the CMPI_Provider manager is created and cmpi providers
+# included in the test environment. Default is true
+ENV PEGASUS_ENABLE_CMPI_PROVIDER_MANAGER=false
+
+# Logging
+# If true, enable the audit-logger that logs all operations that modify
+# entities within the environement
+ENV PEGASUS_ENABLE_AUDIT_LOGGER=true
+# If set false, logs are sent to OpenPegasus specific log files.
+# default is true
+# ENV PEGASUS_USE_SYSLOGS=false
+
+# Interop namespace
+# If set it defines the name for the interop namespace. The allowed
+# values are root/interop or interop.  The default interop namespace if
+# this not set is root/PG_Interop
+ENV PEGASUS_INTEROP_NAMESPACE=root/interop
+
+# Debug build options
+# Enable the compiler debug mode if the following is true. Default is false
+ENV PEGASUS_DEBUG=true
+# If the following is enabled, the trace code is removed from build reducint
+# size. Default is false. TODO: Test this
+# ENV PEGASUS_REMOVE_METHODTRACE=true
+# The following variable set to true reduces size by not including some
+# information in the trace output.  TODO: This may not be documented in
+# the options document. Default is false
+# ENV PEGASUS_NO_FILE_LINE_TRACE=true
+# Enable the trace facility in the pegasus client code. Default is false
+ENV PEGASUS_CLIENT_TRACE_ENABLE=true
+# Causes compiler to remove all PEGASUS_ASSERT statements. default is false
+# TODO test
+# ENV PEGASUS_NOASSERTS=true
+
+# Define repository version.  This is used at least for development builds
+# and installs the DMTF schema defined and available in the directory
+# pegasus/schemas into the namespaces. NOTE: schemas must be installed
+# in that directory with the instructions in that directory to be compilable
+# through the pegasus make repository command.
+# If not defined, the default is DMTF  schema  version 2.41
+#
+# ENV PEGASUS_CIM_SCHEMA=CIM241
+
+# Define the repository type.  OpenPegasus allows variations on the
+# repository implementation for size, speed, etc.  These are define with
+# the following environment variables
+# Repository mode: may be XML or BIN.
+# ENV PEGASUS_REPOSITORY_MODE=XML
+# ENV PEGASUS_ENABLE_COMPRESSED_REPOSITORY=true
+# An alternate implemenation is Sqlite as a repository.  If used it
+# requires installation of sqlite and setting SQLITE_HOME. Default is false
+# ENV PEGASUS_USE_SQLITE_REPOSITORY=true
+
+
+# Reduce the nunber of tests executed during the test phase. This reduces
+# the time to execute the test suite.
+# TODO test this before using
+# ENV PEGASUS_SKIP_MOST_TEST_DIRS=true
+# Reduce the number of test programs built. Speeds up the build process
+# ENV PEGASUS_SKIP_MOST_TEST_DIRS=true
+
+# Defined a specific change to WQL parser for SNIA testing. This allows
+# dotted property names. Default is to not set this.
+# This is considered experimental and for WQL only.
+# ENV PEGASUS_SNIA_EXTENSIONS=true
+
+# Add to path for build
+# TODO: This is for development build.
+ENV PATH=${PEGASUS_HOME}/bin:$PATH
 
 # Add files for building the server image
 COPY ./makefile_smi-build ${PEGASUS_SMI_ROOT}/makefile

--- a/Dockerfile_smi-server
+++ b/Dockerfile_smi-server
@@ -22,19 +22,23 @@ ENV PEGASUS_HOME=${PEGASUS_SMI_ROOT}/home
 # Create directory structure
 RUN mkdir -p ${PEGASUS_HOME}
 
-# Build settings (Debug is currently required for successful building)
+# Run settings
 # Settings below that are flags, with values set to true, enable the action
 # simply through the existance of the variable.  The variables value has no
-# effect.
-ENV PEGASUS_PLATFORM=LINUX_X86_64_GNU
-ENV PEGASUS_DEBUG=true
+# effect.  Note that there are almost NO environment variables to control
+# pegasus execution.  Excution variations are controled through the
+# config variables that can be viewed through the clienc cimconfig
+# and the web admin interface
+# TODO: remove the following after we confirm that they are not needed
+# ENV PEGASUS_DEBUG=true
+# ENV PEGASUS_PLATFORM=LINUX_X86_64_GNU
+# ENV PEGASUS_USE_DEFAULT_MESSAGES=true
+# ENV PEGASUS_HAS_SSL=true
+# ENV PEGASUS_CLIENT_TRACE_ENABLE=true
+# ENV PEGASUS_ENABLE_EXECQUERY=true
+# ENV PEGASUS_PAM_AUTHENTICATION=true
+# ENV OPENSSL=/usr
 ENV PATH=${PEGASUS_HOME}/bin:$PATH
-ENV PEGASUS_USE_DEFAULT_MESSAGES=true
-ENV PEGASUS_HAS_SSL=true
-ENV PEGASUS_CLIENT_TRACE_ENABLE=true
-ENV PEGASUS_ENABLE_EXECQUERY=true
-ENV PEGASUS_PAM_AUTHENTICATION=true
-ENV OPENSSL=/usr
 
 # Add makefile for using this build image
 COPY ./home ${PEGASUS_HOME}

--- a/makefile_smi-build
+++ b/makefile_smi-build
@@ -106,6 +106,17 @@ test-server:
 	make repository
 	make testrepository
 
+provision-server:
+	@echo "Provision the server in build container..."
+
+
+	@echo "Create the repository..."
+	make repository
+
+	# TODO: This will become optional so that the user can create their
+	# specific repository extensions.
+	make testrepository
+
 remove-uneeded-components:
 	@echo "Remove the server unwanted files in the build container..."
 
@@ -117,7 +128,10 @@ remove-uneeded-components:
 	rm -r obj
 
 	@echo remove any trace files
-	rm trace/*
+	TRACEDIR="trace"
+	if [ -d "${TRACEDIR}" ]; then
+		rm ${TRACEDIR}/*
+	endif
 
 	@echo Remove unwanted schemas
 	# TODO: This assumes that CIM241 is the desired schema
@@ -151,8 +165,12 @@ docker-build-server-image: remove-uneeded-components
 docker-push-server-image:
 	@echo "Pushing the built SMI Server image to private image registry..."
 
+	docker logout
+	docker login -u $${DOCKER_USER} -p $${DOCKER_PASSWORD}
 	docker tag ${SERVER_IMAGE}:${SERVER_IMAGE_VERSION} ${DOCKER_REGISTRY}/${SERVER_IMAGE}:${SERVER_IMAGE_VERSION}
 	docker push ${DOCKER_REGISTRY}/${SERVER_IMAGE}:${SERVER_IMAGE_VERSION}
+	docker logout
+
 
 # Subtargets for clean
 clean-build:
@@ -169,6 +187,7 @@ docker-remove-server-images:
 	@echo "Removing server images..."
 
 	@echo "Removing the repository tagged server image..."
+
 	docker rmi ${DOCKER_REGISTRY}/${SERVER_IMAGE}:${SERVER_IMAGE_VERSION}
 
 	@echo "Removing the server image..."


### PR DESCRIPTION
This cleans up and organizes the Dockerfiles and makefile_smi-build.

Extends the set of OpenPegasjs build variables for the server image build
and documents them.  Note that many are commented out so that their
default value applies

Remove most of the OpenPegasus configuration environment variables from the server
dockerfile since they are not needed.

Add a new section to the makefile_smi-build (provision server) which is used to
provision the repository and any test/other repositories.  Provisioning will include building repositories
and installing providers.  Today it simple executes the make_repository target and  testrepository target in pegasus/makefile.
to build the cim repository in namespaces and adds test components to the repository.